### PR TITLE
Fix status bar

### DIFF
--- a/Sources/PeripheralMenu/peripheralMenuController.swift
+++ b/Sources/PeripheralMenu/peripheralMenuController.swift
@@ -387,11 +387,14 @@ open class PeripheralMenuController: UIViewController, UIGestureRecognizerDelega
     
     fileprivate var sbw: UIWindow? {
         
-        let s = "status"
-        let b = "Bar"
-        let w = "Window"
-        
-        return UIApplication.shared.value(forKey: s+b+w) as? UIWindow
+//        let s = "status"
+//        let b = "Bar"
+//        let w = "Window"
+//
+//        return UIApplication.shared.value(forKey: s+b+w) as? UIWindow
+        let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        //let height = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+        return window
     }
     
     fileprivate var showsStatusUnderlay: Bool {

--- a/Sources/PeripheralMenu/peripheralMenuController.swift
+++ b/Sources/PeripheralMenu/peripheralMenuController.swift
@@ -386,15 +386,7 @@ open class PeripheralMenuController: UIViewController, UIGestureRecognizerDelega
     // MARK: - Computed variables -
     
     fileprivate var sbw: UIWindow? {
-        
-//        let s = "status"
-//        let b = "Bar"
-//        let w = "Window"
-//
-//        return UIApplication.shared.value(forKey: s+b+w) as? UIWindow
-        let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-        //let height = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
-        return window
+        return UIApplication.shared.windows.filter {$0.isKeyWindow}.first
     }
     
     fileprivate var showsStatusUnderlay: Bool {

--- a/Sources/PeripheralMenu/peripheralMenuController.swift
+++ b/Sources/PeripheralMenu/peripheralMenuController.swift
@@ -413,7 +413,9 @@ open class PeripheralMenuController: UIViewController, UIGestureRecognizerDelega
     
     fileprivate var previousStatusBarHeight: CGFloat = DefaultStatusBarHeight
     fileprivate var statusBarHeight: CGFloat {
-        return UIApplication.shared.statusBarFrame.size.height > 0 ? UIApplication.shared.statusBarFrame.size.height : DefaultStatusBarHeight
+        let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        let height = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
+        return height > 0 ? height : DefaultStatusBarHeight
     }
     
     fileprivate var hidesStatusBar: Bool {

--- a/Sources/PeripheralMenu/peripheralMenuController.swift
+++ b/Sources/PeripheralMenu/peripheralMenuController.swift
@@ -185,7 +185,7 @@ open class PeripheralMenuController: UIViewController, UIGestureRecognizerDelega
     
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        NotificationCenter.default.addObserver(self, selector: #selector(peripheralMenuController!.repositionViews), name: UIApplication.willChangeStatusBarFrameNotification, object: UIApplication.shared)
+        NotificationCenter.default.addObserver(self, selector: #selector(peripheralMenuController!.repositionViews), name: UIApplication.backgroundRefreshStatusDidChangeNotification, object: UIApplication.shared)
     }
     
     override open func viewWillDisappear(_ animated: Bool) {

--- a/Sources/PeripheralMenu/peripheralMenuController.swift
+++ b/Sources/PeripheralMenu/peripheralMenuController.swift
@@ -184,6 +184,8 @@ open class PeripheralMenuController: UIViewController, UIGestureRecognizerDelega
     }
     
     open override func viewWillAppear(_ animated: Bool) {
+        // more details on the former willChangeStatusBarFrameNotification
+        // [here](https://developer.apple.com/documentation/uikit/uiapplicationdidchangestatusbarframenotification)
         super.viewWillAppear(animated)
         NotificationCenter.default.addObserver(self, selector: #selector(peripheralMenuController!.repositionViews), name: UIApplication.backgroundRefreshStatusDidChangeNotification, object: UIApplication.shared)
     }


### PR DESCRIPTION
* The main problem was that the -statusBarWindow is no longer on the UIApplication.shared.window property, but instead, finding the keyWindow out of all the windows is a working solution for this problem. 
* The second problem was the deprecated -willChangeStatusBarFrameNotification. I documented this with a URL to Apple's further explanation. However, I don't care to investigate further at this time.